### PR TITLE
fix: optional expectation on tuple

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,1 @@
+Adam Desivi <desivi@desivi.com>

--- a/src/validators/tuple-validator.ts
+++ b/src/validators/tuple-validator.ts
@@ -42,27 +42,11 @@ export class TupleValidator extends PatternValidator
       );
     }
 
-    if (value.length !== tupleOrExpect.length) {
-      let valueElement: any;
-      let expectationItem: any;
-      if (value.length < tupleOrExpect.length) {
-        valueElement = value[value.length];
-        expectationItem = tupleOrExpect[value.length];
-      }
-
-      if (value.length > tupleOrExpect.length) {
-        valueElement = value[tupleOrExpect.length];
-        expectationItem = tupleOrExpect[tupleOrExpect.length];
-      }
-
-      throw new NotAMemberError(
-        `Expected %s to be matching an %s`,
-        this.describe(valueElement),
-        this.describe(expectationItem)
-      );
+    let source = tupleOrExpect;
+    if (value.length > tupleOrExpect.length) {
+      source = value;
     }
-
-    for (let i = 0; i < tupleOrExpect.length; i++) {
+    for (let i = 0; i < source.length; i++) {
       const valueElement = value[i];
       const expectationItem = tupleOrExpect[i];
       try {

--- a/test/integration/matches.test.ts
+++ b/test/integration/matches.test.ts
@@ -15,6 +15,7 @@ import {
   typeOf,
   iof,
   list,
+  tuple,
 } from '../../src/index';
 
 @define()
@@ -216,6 +217,17 @@ describe(`matching`, () => {
       oneOf('win', /fai/g),
       'Expected String("fail") to be one of: "win", /fai/g',
     ],
+    // Tuple
+    [
+      [1, 2, 3],
+      tuple(Number, Number, optional(Number)),
+      'Expected String("fail") to be one of: "fail", "win"',
+    ],
+    [
+      [1, 2],
+      tuple(Number, Number, optional(Number)),
+      'Expected String("fail") to be one of: "fail", "win"',
+    ],
     // Maybe
     [undefined, maybe(String), 'Expected undefined to be a String'],
     [null, maybe(String), 'Expected null to be a String'],
@@ -288,7 +300,7 @@ describe(`matching`, () => {
     // Where
     [
       'yes',
-      where(value => {
+      where((value) => {
         return value === 'yes';
       }),
       'Failed Where validation',


### PR DESCRIPTION
This PR fixes issue with `TupleValidator` not supporting optional elements.

### Summary

`TupleValidator` not supporting optional elements. 

### What is the current _bug_ behavior?

Any definition of tuple like 
```ts
@define('Point')
export class Point  {
  public coordinates: [number, number, number?];
  ...
}
```

Will result in error if the 3d argument is not provided.

### What is the expected _correct_ behavior?

Optional arguments should be ignored.

---

## Review Checklist

### Basics

- [x] PR information has been filled
- [x] PR has been assigned
- [x] PR uses appropriate labels (`fix`)
- [x] PR has a all necessary bug-description fields filled
- [ ] PR is peer reviewed <sup>**optional**</sup>
- [x] Commits contain a meaningful commit messages and fallow syntax of [Conventional Commits](http://www.conventionalcommits.org/)
- [x] On dependency change: `yarn.lock` file is updated and committed
- [x] `CHANGELOG.md` and references to project's version are unchanged(let [semantic-release](https://github.com/semantic-release/semantic-release) do the magic)

### Code Quality

- [x] Code is properly typed with TypeScript
- [x] Code `builds`(`yarn build`)
- [x] Code is `formatted`(`yarn test:format`)
- [x] Code is `linted`(`yarn test:lint`)
- [x] Code is unit `tested`(`yarn test:unit`)
- [x] Code is integration `tested`(`yarn test:integration`)

### Testing

- [x] New fix is covered by unit tests
- [x] New fix is covered by integration tests
- [x] All existing tests are still up-to-date

### After Review

- [x] Merge the PR
- [x] Delete the source branch
- [ ] Move the ticket to `done` <sup>**optional**</sup>